### PR TITLE
/me and /do command

### DIFF
--- a/Plugins/Public/playercntl_plugin/Main.cpp
+++ b/Plugins/Public/playercntl_plugin/Main.cpp
@@ -931,6 +931,8 @@ USERCMD UserCmds[] =
 	{ L"/drc",		GiveCash::UserCmd_DrawCash,		L"Usage: /drawcash <charname> <code> <cash> or /drc ..." },
 	{ L"/shc",		GiveCash::UserCmd_ShowCash,		L"Usage: /showcash <charname> <code> or /shc ..." },
 	{ L"/drawcash",		GiveCash::UserCmd_DrawCash,		L"Usage: /drawcash <charname> <code> <cash> or /drc ..." },
+	{ L"/me",			Message::UserCmd_Me, L"Usage: /me <message>" },
+	{ L"/do",			Message::UserCmd_Do, L"Usage: /do <message>" },
 	{ L"/group",		Message::UserCmd_GroupMsg, L"Usage: /group <message> or /g ..." },
 	{ L"/g",			Message::UserCmd_GroupMsg, L"Usage: /group <message> or /g ..." },
 	{ L"/local",		Message::UserCmd_LocalMsg, L"Usage: /local <message> or /l ...>" },

--- a/Plugins/Public/playercntl_plugin/Main.h
+++ b/Plugins/Public/playercntl_plugin/Main.h
@@ -250,6 +250,9 @@ namespace Message
 	bool UserCmd_BuiltInCmdHelp(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
 	bool UserCmd_MailShow(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
 	bool UserCmd_MailDel(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
+	bool UserCmd_Me(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
+	bool UserCmd_Do(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage);
+	bool RedText(wstring wscXMLMsg, uint iSystemID);
 	void UserCmd_Process(uint iClientID, const wstring &wscCmd);
 
 	void AdminCmd_SendMail(CCmds *cmds, const wstring &wscCharname, const wstring &wscMsg);

--- a/Plugins/Public/playercntl_plugin/Message.cpp
+++ b/Plugins/Public/playercntl_plugin/Message.cpp
@@ -1476,6 +1476,64 @@ namespace Message
 		cmds->Print(L"OK message saved to mailbox\n");
 	}
 
+	/** Me command allow players to type "/me powers his engines" which would print: "Trent powers his engines" */
+	bool Message::UserCmd_Me(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
+	{
+		wstring charname = (const wchar_t*)Players.GetActiveCharacterName(iClientID);
+		uint iSystemID;
+		pub::Player::GetSystem(iClientID, iSystemID);
+
+		// Encode message using the death message style (red text).
+		wstring wscXMLMsg = L"<TRA data=\"" + set_wscDeathMsgStyleSys + L"\" mask=\"-1\"/> <TEXT>";
+		wscXMLMsg += charname + L" ";
+		wscXMLMsg += XMLText(GetParamToEnd(wscParam, ' ', 0));
+		wscXMLMsg += L"</TEXT>";
+
+		return RedText(wscXMLMsg, iSystemID);
+	}
+
+	/** Do command allow players to type "/do Nomad fighters detected" which would print: "Nomad fighters detected" in the standard red text */
+	bool Message::UserCmd_Do(uint iClientID, const wstring &wscCmd, const wstring &wscParam, const wchar_t *usage)
+	{
+		uint iSystemID;
+		pub::Player::GetSystem(iClientID, iSystemID);
+
+		// Encode message using the death message style (red text).
+		wstring wscXMLMsg = L"<TRA data=\"" + set_wscDeathMsgStyleSys + L"\" mask=\"-1\"/> <TEXT>";
+		wscXMLMsg += XMLText(GetParamToEnd(wscParam, ' ', 0));
+		wscXMLMsg += L"</TEXT>";
+
+		return RedText(wscXMLMsg, iSystemID);
+	}
+
+	bool Message::RedText(wstring wscXMLMsg, uint iSystemID) {
+		char szBuf[0xFFFF];
+		uint iRet;
+		if (!HKHKSUCCESS(HkFMsgEncodeXML(wscXMLMsg, szBuf, sizeof(szBuf), iRet)))
+			return false;
+
+		// Send to all players in system
+		struct PlayerData *pPD = 0;
+		while (pPD = Players.traverse_active(pPD))
+		{
+			uint iClientID = HkGetClientIdFromPD(pPD);
+			uint iClientSystemID = 0;
+			pub::Player::GetSystem(iClientID, iClientSystemID);
+
+			char *szXMLBuf;
+			int iXMLBufRet;
+			char *szXMLBufSys;
+			int iXMLBufRetSys;
+
+			szXMLBuf = szBuf;
+			iXMLBufRet = iRet;
+
+			if (iSystemID == iClientSystemID)
+				HkFMsgSendChat(iClientID, szXMLBuf, iXMLBufRet);
+		}
+		return true;
+	}
+
 	/// Hook for ship distruction. It's easier to hook this than the PlayerDeath one.
 	/// Drop a percentage of cargo + some loot representing ship bits.
 	void Message::SendDeathMsg(const wstring &wscMsg, uint iSystemID, uint iClientIDVictim, uint iClientIDKiller)


### PR DESCRIPTION
Me command allow players to type "/me powers his engines" which would print: "Trent powers his engines".

Do command allow players to type "/do Nomad fighters detected" which would print: "Nomad fighters detected" in the standard red text.